### PR TITLE
Add Static Web Apps configuration for proper routing and mime types

### DIFF
--- a/docs/staticwebapp.config.json
+++ b/docs/staticwebapp.config.json
@@ -1,0 +1,18 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/images/*.{png,jpg,gif}", "/css/*", "/js/*", "/models/*"]
+  },
+  "mimeTypes": {
+    ".json": "text/json",
+    ".bin": "application/octet-stream"
+  },
+  "routes": [
+    {
+      "route": "/models/*",
+      "headers": {
+        "cache-control": "must-revalidate, max-age=86400"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request includes changes to the `docs/staticwebapp.config.json` file to improve the configuration of a static web application. The most important changes include adding navigation fallback, defining MIME types, and specifying caching headers for certain routes.

Configuration improvements:

* Added a `navigationFallback` section to rewrite requests to `/index.html` and exclude specific file types from this rule.
* Defined MIME types for `.json` and `.bin` files to ensure they are served with the correct content types.
* Added a route for `/models/*` with caching headers to enforce revalidation and set a maximum age for cache control.