### PR TITLE
Update azure-static-web-apps-witty-hill-01552b800.yml

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-hill-01552b800.yml
+++ b/.github/workflows/azure-static-web-apps-witty-hill-01552b800.yml
@@ -32,8 +32,6 @@ jobs:
           
       - name: Build
         run: npm run build
-        env:
-          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Build And Deploy
         id: builddeploy


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/azure-static-web-apps-witty-hill-01552b800.yml` file. The change removes the `env` section that sets the `NODE_OPTIONS` environment variable during the build step.

* [`.github/workflows/azure-static-web-apps-witty-hill-01552b800.yml`](diffhunk://#diff-c1517fb13a0a1641937d43fde6c164f13914dde6e829cda726de7600056623ebL35-L36): Removed the `env` section that set `NODE_OPTIONS` to `--openssl-legacy-provider` during the build step.