### PR TITLE
Fix package.json syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-  "serve": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
-  "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
-  "lint": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service lint"
-}
+    "serve": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
+    "lint": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service lint"
+  },
   "dependencies": {
     "core-js": "^3.6.5",
     "customvision-tfjs": "^1.0.1",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change adds a missing comma after the `scripts` section to ensure proper JSON formatting.