### PR TITLE
Update GitHub Actions workflow to use correct app_location

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-hill-01552b800.yml
+++ b/.github/workflows/azure-static-web-apps-witty-hill-01552b800.yml
@@ -42,10 +42,10 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_HILL_01552B800 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "/"
+          app_location: "docs"
           api_location: ""
-          output_location: "docs"
-          skip_app_build: true # Skip build as we've already built the app
+          output_location: ""
+          skip_app_build: true
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/azure-static-web-apps-witty-hill-01552b800.yml` file to update the configuration for the Azure Static Web Apps deployment.

Deployment configuration update:

* Changed the `app_location` from `/` to `docs` to specify the correct location of the application.
* Updated the `output_location` to an empty string, removing the previous `docs` value.
* Retained the `skip_app_build: true` configuration, ensuring the build process is skipped as the app is already built.